### PR TITLE
Updated to use Python3 Pathlib library

### DIFF
--- a/sysfs/__init__.py
+++ b/sysfs/__init__.py
@@ -13,48 +13,47 @@ Usage::
         print bdev, str(int(bdev.size) / 1024 / 1024) + 'M'
 """
 
-__all__ = ["sys", "Node"]
+__all__ = ['sys', 'Node']
+__license__ = "MIT"
 
-from os import listdir
-from os.path import isdir, isfile, join, realpath, basename
-
+from pathlib import Path, PosixPath
 
 class Node(object):
-    __slots__ = ["_path_", "__dict__"]
+    __slots__ = ['_path_', '__dict__']
 
-    def __init__(self, path="/sys"):
-        self._path_ = realpath(path)
-        if not self._path_.startswith("/sys/") and not "/sys" == self._path_:
-            raise RuntimeError("Using this on non-sysfs files is dangerous!")
+    def __init__(self, path: str='/sys'):
+        self._path_ = path if isinstance(path, PosixPath) else Path(path).resolve()
+        if not str(self._path_).startswith('/sys') and Path(self._path_).is_dir():
+            raise RuntimeError('Using this on non-sysfs files is dangerous!')
 
-        self.__dict__.update(dict.fromkeys(listdir(self._path_)))
+        self.__dict__.update(dict.fromkeys([_ for _ in self._path_.iterdir()]))
 
     def __repr__(self):
         return '<sysfs.Node "%s">' % self._path_
 
     def __str__(self):
-        return basename(self._path_)
+        return self._path_.name
 
-    def __setattr__(self, name, val):
-        if name.startswith("_"):
+    def __setattr__(self, name: str, val):
+        if name.startswith('_'):
             return object.__setattr__(self, name, val)
 
-        path = realpath(join(self._path_, name))
-        if isfile(path):
-            with open(path, "w") as fp:
+        path = self._path_ / name
+        if path.is_file():
+            with path.open('w') as fp:
                 fp.write(val)
         else:
-            raise RuntimeError("Cannot write to non-files.")
+            raise RuntimeError('Cannot write to non-files.')
 
     def __getattribute__(self, name):
-        if name.startswith("_"):
+        if name.startswith('_'):
             return object.__getattribute__(self, name)
 
-        path = realpath(join(self._path_, name))
-        if isfile(path):
-            with open(path, "r") as fp:
+        path = self._path_ / name
+        if path.is_file():
+            with path.open('r') as fp:
                 return fp.read().strip()
-        elif isdir(path):
+        elif path.is_dir():
             return Node(path)
 
     def __setitem__(self, name, val):
@@ -64,7 +63,7 @@ class Node(object):
         return getattr(self, name)
 
     def __iter__(self):
-        return iter(getattr(self, name) for name in listdir(self._path_))
+        return iter(getattr(self, name) for name in self._path_.iterdir())
 
 
 sys = Node()


### PR DESCRIPTION
Refactored code to use the Python3 Pathlib library, which streamlines the path manipulation and file handling.

There does appear to be an underlying bug in the original source though:
When referencing the `class` node, you get a SyntaxError raised. Work around is to reference the dict entry or getattr entry.